### PR TITLE
Implement simple symbolic AI modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+symbolic_ai/data/memory.json

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Symbolic AI Genesis
 
-This project explores building a lightweight symbolic AI that learns letters, sounds, and meanings without large pretrained datasets. The structure is organized in the `symbolic_ai` package with modules for vision, audio, web scraping, cognition, creativity, and tools. Each module includes minimal placeholder implementations and tests to ensure the framework runs.
+This project explores building a lightweight symbolic AI that learns letters,
+sounds, and simple meanings without large pretrained datasets. The code is
+split across the `symbolic_ai` package with modules for vision, audio, web
+scraping, cognition, creativity and supporting tools.
+
+Run the full test suite with:
+
+```bash
+python3 -m symbolic_ai.tests.test_all
+```
+
+The tests exercise the small but working functionality implemented in each
+module.

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from symbolic_ai.core.memory_manager import MemoryManager
 def main():
     memory = MemoryManager()
     brain = BrainController(memory)
-    print(brain.run())
+    print(brain.run("a"))
 
 
 if __name__ == "__main__":

--- a/symbolic_ai/audio/letter_to_sound_mapper.py
+++ b/symbolic_ai/audio/letter_to_sound_mapper.py
@@ -1,5 +1,35 @@
 class LetterToSoundMapper:
-    """Maps letters to phonics."""
+    """Maps letters to simple English phonetic representations."""
 
-    def map(self, letter):
-        return "sound"
+    _table = {
+        "a": "ay",
+        "b": "bee",
+        "c": "cee",
+        "d": "dee",
+        "e": "ee",
+        "f": "ef",
+        "g": "gee",
+        "h": "aitch",
+        "i": "eye",
+        "j": "jay",
+        "k": "kay",
+        "l": "el",
+        "m": "em",
+        "n": "en",
+        "o": "oh",
+        "p": "pee",
+        "q": "cue",
+        "r": "ar",
+        "s": "ess",
+        "t": "tee",
+        "u": "you",
+        "v": "vee",
+        "w": "double you",
+        "x": "ex",
+        "y": "why",
+        "z": "zee",
+    }
+
+    def map(self, letter: str) -> str:
+        """Return the phonetic sound for a given letter."""
+        return self._table.get(letter.lower(), "")

--- a/symbolic_ai/audio/speech_letter_linker.py
+++ b/symbolic_ai/audio/speech_letter_linker.py
@@ -1,5 +1,8 @@
 class SpeechLetterLinker:
-    """Links speech to letters."""
+    """Links simple spoken letter strings to symbols."""
 
-    def link(self, audio):
-        return []
+    def link(self, audio: str) -> list[str]:
+        """Convert a string of spoken letters into a list of uppercase letters."""
+        if not audio:
+            return []
+        return [part.strip().upper()[:1] for part in audio.split() if part.strip()]

--- a/symbolic_ai/audio/test_audio.py
+++ b/symbolic_ai/audio/test_audio.py
@@ -1,16 +1,24 @@
+import unittest
+
 from .speech_letter_linker import SpeechLetterLinker
 from .letter_to_sound_mapper import LetterToSoundMapper
 from .video_speech_extractor import VideoSpeechExtractor
 
 
-def test_link():
-    linker = SpeechLetterLinker()
-    assert linker.link(None) == []
+class TestAudio(unittest.TestCase):
+    def test_link(self):
+        linker = SpeechLetterLinker()
+        self.assertEqual(linker.link("a"), ["A"])
 
-def test_map():
-    mapper = LetterToSoundMapper()
-    assert mapper.map('a') == 'sound'
+    def test_map(self):
+        mapper = LetterToSoundMapper()
+        self.assertEqual(mapper.map("b"), "bee")
 
-def test_extract():
-    extractor = VideoSpeechExtractor()
-    assert extractor.extract(None) == b""
+    def test_extract(self):
+        extractor = VideoSpeechExtractor()
+        data = extractor.extract(b"hello")
+        self.assertIsInstance(data, bytes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/symbolic_ai/audio/video_speech_extractor.py
+++ b/symbolic_ai/audio/video_speech_extractor.py
@@ -1,5 +1,10 @@
 class VideoSpeechExtractor:
-    """Extracts speech from video."""
+    """Dummy extractor that returns raw bytes from provided content."""
 
-    def extract(self, video_url):
+    def extract(self, data: bytes | str) -> bytes:
+        """Return ``data`` as bytes, simulating extraction."""
+        if isinstance(data, bytes):
+            return data
+        if isinstance(data, str):
+            return data.encode("utf-8")
         return b""

--- a/symbolic_ai/cognition/emotional_letter_mapper.py
+++ b/symbolic_ai/cognition/emotional_letter_mapper.py
@@ -1,5 +1,10 @@
 class EmotionalLetterMapper:
-    """Maps symbols to emotions."""
+    """Associate letters with basic emotions."""
 
-    def emotion(self, letter):
-        return "neutral"
+    _emotion = {
+        "z": "sleepy",
+    }
+
+    def emotion(self, letter: str) -> str:
+        """Return the emotion linked to ``letter``."""
+        return self._emotion.get(letter.lower(), "neutral")

--- a/symbolic_ai/cognition/letter_meaning_engine.py
+++ b/symbolic_ai/cognition/letter_meaning_engine.py
@@ -1,5 +1,11 @@
 class LetterMeaningEngine:
-    """Derives meaning from context."""
+    """Provide a very small mapping of letters to symbolic meaning."""
 
-    def meaning(self, letter):
-        return "meaning"
+    _meaning = {
+        "a": "start",
+        "z": "end",
+    }
+
+    def meaning(self, letter: str) -> str:
+        """Return a symbolic meaning for ``letter`` if known."""
+        return self._meaning.get(letter.lower(), "unknown")

--- a/symbolic_ai/cognition/symbolic_pattern_discoverer.py
+++ b/symbolic_ai/cognition/symbolic_pattern_discoverer.py
@@ -1,5 +1,8 @@
 class SymbolicPatternDiscoverer:
-    """Recognizes patterns in sequences."""
+    """Recognizes simple frequency patterns in sequences."""
 
-    def discover(self, sequence):
-        return []
+    def discover(self, sequence: str) -> dict:
+        freq = {}
+        for ch in sequence:
+            freq[ch] = freq.get(ch, 0) + 1
+        return freq

--- a/symbolic_ai/cognition/test_cognition.py
+++ b/symbolic_ai/cognition/test_cognition.py
@@ -1,16 +1,23 @@
+import unittest
+
 from .letter_meaning_engine import LetterMeaningEngine
 from .symbolic_pattern_discoverer import SymbolicPatternDiscoverer
 from .emotional_letter_mapper import EmotionalLetterMapper
 
 
-def test_meaning():
-    engine = LetterMeaningEngine()
-    assert engine.meaning('a') == 'meaning'
+class TestCognition(unittest.TestCase):
+    def test_meaning(self):
+        engine = LetterMeaningEngine()
+        self.assertEqual(engine.meaning("a"), "start")
 
-def test_discover():
-    discoverer = SymbolicPatternDiscoverer()
-    assert discoverer.discover('abc') == []
+    def test_discover(self):
+        discoverer = SymbolicPatternDiscoverer()
+        self.assertEqual(discoverer.discover("abca"), {"a": 2, "b": 1, "c": 1})
 
-def test_emotion():
-    mapper = EmotionalLetterMapper()
-    assert mapper.emotion('a') == 'neutral'
+    def test_emotion(self):
+        mapper = EmotionalLetterMapper()
+        self.assertEqual(mapper.emotion("z"), "sleepy")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/symbolic_ai/core/brain_controller.py
+++ b/symbolic_ai/core/brain_controller.py
@@ -1,10 +1,16 @@
+from .symbolic_evolver import SymbolicEvolver
+
+
 class BrainController:
     """Main symbolic brain loop controller."""
 
-    def __init__(self, memory_manager):
-        self.memory_manager = memory_manager
+    def __init__(self, memory_manager: "MemoryManager"):
+        self.memory = memory_manager
+        self.evolver = SymbolicEvolver()
 
-    def run(self):
-        """Run a single learning iteration."""
-        # Placeholder for main loop logic
-        return "running"
+    def run(self, symbol: str = "a") -> str:
+        """Process ``symbol`` through the evolution pipeline and store it."""
+        evolved = self.evolver.evolve(symbol)
+        self.memory.add_pattern(evolved)
+        self.memory.prune()
+        return evolved

--- a/symbolic_ai/core/memory_manager.py
+++ b/symbolic_ai/core/memory_manager.py
@@ -1,12 +1,31 @@
+import json
+from pathlib import Path
+
+
 class MemoryManager:
-    """Manage symbolic memory with compression and pruning."""
+    """Manage symbolic memory as a small JSON based store."""
+
+    MEMORY_FILE = Path(__file__).resolve().parent.parent / "data" / "memory.json"
 
     def __init__(self):
         self.patterns = []
+        if self.MEMORY_FILE.exists():
+            try:
+                self.patterns = json.loads(self.MEMORY_FILE.read_text())
+            except Exception:
+                self.patterns = []
 
-    def add_pattern(self, pattern):
+    def add_pattern(self, pattern: str) -> None:
+        """Add a new symbolic pattern and persist it."""
         self.patterns.append(pattern)
+        self._save()
 
-    def prune(self):
-        if self.patterns:
+    def prune(self, max_size: int = 10) -> None:
+        """Remove oldest patterns if memory exceeds ``max_size``."""
+        while len(self.patterns) > max_size:
             self.patterns.pop(0)
+        self._save()
+
+    def _save(self) -> None:
+        self.MEMORY_FILE.parent.mkdir(parents=True, exist_ok=True)
+        self.MEMORY_FILE.write_text(json.dumps(self.patterns))

--- a/symbolic_ai/core/symbolic_evolver.py
+++ b/symbolic_ai/core/symbolic_evolver.py
@@ -1,6 +1,8 @@
 class SymbolicEvolver:
-    """Learns abstract structure and meaning from symbols."""
+    """Very small symbolic evolution engine."""
 
-    def evolve(self, symbol):
-        # Placeholder for evolution logic
-        return f"evolved_{symbol}"
+    def evolve(self, symbol: str) -> str:
+        """Return a transformed version of ``symbol`` used as a toy evolution."""
+        if not isinstance(symbol, str):
+            raise TypeError("symbol must be a string")
+        return symbol[::-1].upper()

--- a/symbolic_ai/core/symbolic_test_suite.py
+++ b/symbolic_ai/core/symbolic_test_suite.py
@@ -5,5 +5,5 @@ from .memory_manager import MemoryManager
 def self_check():
     mem = MemoryManager()
     brain = BrainController(mem)
-    result = brain.run()
-    return result == "running"
+    result = brain.run("b")
+    return mem.patterns and mem.patterns[-1] == result

--- a/symbolic_ai/core/test_dummy.py
+++ b/symbolic_ai/core/test_dummy.py
@@ -1,10 +1,16 @@
 # symbolic_ai/core/test_dummy.py
 
 import unittest
+from .brain_controller import BrainController
+from .memory_manager import MemoryManager
 
-class TestDummy(unittest.TestCase):
-    def test_truth(self):
-        self.assertTrue(True)
+
+class TestCore(unittest.TestCase):
+    def test_brain_memory_cycle(self):
+        mem = MemoryManager()
+        brain = BrainController(mem)
+        result = brain.run("c")
+        self.assertIn(result, mem.patterns)
 
 if __name__ == '__main__':
     unittest.main()

--- a/symbolic_ai/creativity/alphabet_poet.py
+++ b/symbolic_ai/creativity/alphabet_poet.py
@@ -1,5 +1,7 @@
 class AlphabetPoet:
-    """Generates poems from letters."""
+    """Generates a tiny two-line poem about a letter."""
 
-    def compose(self, letter):
-        return f"poem about {letter}"
+    def compose(self, letter: str) -> str:
+        line1 = f"{letter.upper()} stands strong."
+        line2 = f"{letter.lower()} whispers along."
+        return "\n".join([line1, line2])

--- a/symbolic_ai/creativity/imaginary_language_builder.py
+++ b/symbolic_ai/creativity/imaginary_language_builder.py
@@ -1,5 +1,6 @@
 class ImaginaryLanguageBuilder:
-    """Invents new alphabets."""
+    """Generate a small imaginary alphabet from shifted ASCII letters."""
 
-    def invent(self):
-        return []
+    def invent(self, count: int = 3) -> list[str]:
+        base = ord('α')  # greek alpha as start
+        return [chr(base + i) for i in range(count)]

--- a/symbolic_ai/creativity/symbolic_art_generator.py
+++ b/symbolic_ai/creativity/symbolic_art_generator.py
@@ -1,5 +1,8 @@
 class SymbolicArtGenerator:
-    """Creates art from letters."""
+    """Create a mini ASCII art representation of a letter."""
 
-    def create(self, letter):
-        return f"art_{letter}"
+    def create(self, letter: str) -> str:
+        top = f" /{letter}\ "
+        mid = f"| {letter} |"
+        bot = f" \_{letter}_/"
+        return "\n".join([top, mid, bot])

--- a/symbolic_ai/creativity/test_creativity.py
+++ b/symbolic_ai/creativity/test_creativity.py
@@ -1,16 +1,23 @@
+import unittest
+
 from .alphabet_poet import AlphabetPoet
 from .symbolic_art_generator import SymbolicArtGenerator
 from .imaginary_language_builder import ImaginaryLanguageBuilder
 
 
-def test_poet():
-    poet = AlphabetPoet()
-    assert "poem" in poet.compose('a')
+class TestCreativity(unittest.TestCase):
+    def test_poet(self):
+        poet = AlphabetPoet()
+        self.assertIn("stands", poet.compose("a"))
 
-def test_art():
-    art = SymbolicArtGenerator()
-    assert art.create('b') == 'art_b'
+    def test_art(self):
+        art = SymbolicArtGenerator()
+        self.assertIn("b", art.create("b"))
 
-def test_language():
-    builder = ImaginaryLanguageBuilder()
-    assert builder.invent() == []
+    def test_language(self):
+        builder = ImaginaryLanguageBuilder()
+        self.assertIsInstance(builder.invent(), list)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/symbolic_ai/tools/browser_reader.py
+++ b/symbolic_ai/tools/browser_reader.py
@@ -1,5 +1,9 @@
-class BrowserReader:
-    """Parses HTML text and images."""
+import re
 
-    def read(self, url):
-        return ""
+
+class BrowserReader:
+    """Parses provided HTML text and returns plain text."""
+
+    def read(self, html: str) -> str:
+        cleaned = re.sub(r"<[^>]+>", "", html or "")
+        return cleaned.strip()

--- a/symbolic_ai/tools/camera_handler.py
+++ b/symbolic_ai/tools/camera_handler.py
@@ -1,5 +1,6 @@
 class CameraHandler:
-    """Handles webcam capture."""
+    """Handles webcam capture (returns 1x1 pixel matrix)."""
 
-    def capture(self):
-        return None
+    def capture(self) -> list[list[int]]:
+        """Return a single white pixel represented as nested list."""
+        return [[255]]

--- a/symbolic_ai/tools/font_downloader.py
+++ b/symbolic_ai/tools/font_downloader.py
@@ -1,5 +1,5 @@
 class FontDownloader:
-    """Fetches fonts dynamically."""
+    """Pretend to download fonts by validating the name."""
 
-    def download(self, name):
-        return True
+    def download(self, name: str) -> bool:
+        return bool(name)

--- a/symbolic_ai/tools/speech_transcriber.py
+++ b/symbolic_ai/tools/speech_transcriber.py
@@ -1,5 +1,10 @@
 class SpeechTranscriber:
-    """Converts audio to text."""
+    """Converts raw bytes to a UTF-8 string (mock transcription)."""
 
-    def transcribe(self, audio):
-        return ""
+    def transcribe(self, audio: bytes | str) -> str:
+        if isinstance(audio, bytes):
+            try:
+                return audio.decode("utf-8")
+            except Exception:
+                return ""
+        return str(audio or "")

--- a/symbolic_ai/tools/test_tools.py
+++ b/symbolic_ai/tools/test_tools.py
@@ -1,21 +1,28 @@
+import unittest
+
 from .camera_handler import CameraHandler
 from .browser_reader import BrowserReader
 from .speech_transcriber import SpeechTranscriber
 from .font_downloader import FontDownloader
 
 
-def test_camera():
-    cam = CameraHandler()
-    assert cam.capture() is None
+class TestTools(unittest.TestCase):
+    def test_camera(self):
+        cam = CameraHandler()
+        self.assertIsNotNone(cam.capture())
 
-def test_browser():
-    br = BrowserReader()
-    assert br.read('') == ''
+    def test_browser(self):
+        br = BrowserReader()
+        self.assertEqual(br.read("<p>hi</p>"), "hi")
 
-def test_transcriber():
-    tr = SpeechTranscriber()
-    assert tr.transcribe(None) == ''
+    def test_transcriber(self):
+        tr = SpeechTranscriber()
+        self.assertEqual(tr.transcribe(b"hi"), "hi")
 
-def test_font_downloader():
-    fd = FontDownloader()
-    assert fd.download('arial')
+    def test_font_downloader(self):
+        fd = FontDownloader()
+        self.assertTrue(fd.download("arial"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/symbolic_ai/vision/character_shape_trainer.py
+++ b/symbolic_ai/vision/character_shape_trainer.py
@@ -1,6 +1,13 @@
 class CharacterShapeTrainer:
-    """Trains on fonts and styles."""
+    """Stores simple numeric patterns for letters."""
 
-    def train(self, image):
-        # Placeholder training logic
+    def __init__(self):
+        self.patterns: dict[str, int] = {}
+
+    def render_letter(self, letter: str) -> list[int]:
+        return [ord(letter)]
+
+    def train(self, image: list[int], letter: str = "?") -> bool:
+        pixels = sum(image)
+        self.patterns[letter] = pixels
         return True

--- a/symbolic_ai/vision/handwriting_decoder.py
+++ b/symbolic_ai/vision/handwriting_decoder.py
@@ -1,5 +1,7 @@
 class HandwritingDecoder:
-    """Learns handwritten letters."""
+    """Very small decoder that checks if any pixels are present."""
 
-    def decode(self, image):
-        return "?"
+    def decode(self, image) -> str:
+        if image is None:
+            return "?"
+        return "#" if sum(image) > 0 else "?"

--- a/symbolic_ai/vision/live_character_reader.py
+++ b/symbolic_ai/vision/live_character_reader.py
@@ -1,5 +1,11 @@
+from symbolic_ai.tools.camera_handler import CameraHandler
+
+
 class LiveCharacterReader:
-    """Camera-based real-time recognition."""
+    """Camera-based real-time recognition (mocked)."""
+
+    def __init__(self):
+        self.camera = CameraHandler()
 
     def read(self):
-        return None
+        return self.camera.capture()

--- a/symbolic_ai/vision/shape_identifier.py
+++ b/symbolic_ai/vision/shape_identifier.py
@@ -1,6 +1,10 @@
 class ShapeIdentifier:
-    """Matches patterns for unknown letters."""
+    """Matches patterns for unknown letters based on pixel counts."""
 
-    def identify(self, image):
-        # Placeholder identification logic
-        return "?"
+    def __init__(self, patterns: dict[str, int]):
+        self.patterns = patterns
+
+    def identify(self, image: list[int]) -> str:
+        pixels = sum(image)
+        closest = min(self.patterns.items(), key=lambda kv: abs(kv[1] - pixels), default=("?", None))
+        return closest[0]

--- a/symbolic_ai/vision/test_vision.py
+++ b/symbolic_ai/vision/test_vision.py
@@ -1,21 +1,32 @@
+import unittest
+
 from .character_shape_trainer import CharacterShapeTrainer
 from .shape_identifier import ShapeIdentifier
 from .handwriting_decoder import HandwritingDecoder
 from .live_character_reader import LiveCharacterReader
 
 
-def test_train():
-    trainer = CharacterShapeTrainer()
-    assert trainer.train(None)
+class TestVision(unittest.TestCase):
+    def test_train(self):
+        trainer = CharacterShapeTrainer()
+        img = trainer.render_letter("a")
+        self.assertTrue(trainer.train(img, "a"))
 
-def test_identify():
-    identifier = ShapeIdentifier()
-    assert identifier.identify(None) == "?"
+    def test_identify(self):
+        trainer = CharacterShapeTrainer()
+        img = trainer.render_letter("b")
+        trainer.train(img, "b")
+        identifier = ShapeIdentifier(trainer.patterns)
+        self.assertEqual(identifier.identify(img), "b")
 
-def test_decode():
-    decoder = HandwritingDecoder()
-    assert decoder.decode(None) == "?"
+    def test_decode(self):
+        decoder = HandwritingDecoder()
+        self.assertEqual(decoder.decode(None), "?")
 
-def test_live_reader():
-    reader = LiveCharacterReader()
-    assert reader.read() is None
+    def test_live_reader(self):
+        reader = LiveCharacterReader()
+        self.assertIsNotNone(reader.read())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/symbolic_ai/web/deepseek_ai_connector.py
+++ b/symbolic_ai/web/deepseek_ai_connector.py
@@ -1,5 +1,5 @@
 class DeepSeekAIConnector:
-    """Queries LLMs for enrichment."""
+    """Mock connector returning uppercase responses."""
 
-    def query(self, text):
-        return "response"
+    def query(self, text: str) -> str:
+        return text.upper()

--- a/symbolic_ai/web/test_web.py
+++ b/symbolic_ai/web/test_web.py
@@ -1,16 +1,23 @@
+import unittest
+
 from .web_letter_crawler import WebLetterCrawler
 from .youtube_letter_learner import YouTubeLetterLearner
 from .deepseek_ai_connector import DeepSeekAIConnector
 
 
-def test_crawl():
-    crawler = WebLetterCrawler()
-    assert crawler.crawl('') == ''
+class TestWeb(unittest.TestCase):
+    def test_crawl(self):
+        crawler = WebLetterCrawler()
+        self.assertIn("hello", crawler.crawl("http://example.com/hello"))
 
-def test_learn():
-    learner = YouTubeLetterLearner()
-    assert learner.learn('')
+    def test_learn(self):
+        learner = YouTubeLetterLearner()
+        self.assertTrue(learner.learn("http://yt"))
 
-def test_query():
-    connector = DeepSeekAIConnector()
-    assert connector.query('hi') == 'response'
+    def test_query(self):
+        connector = DeepSeekAIConnector()
+        self.assertEqual(connector.query("hi"), "HI")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/symbolic_ai/web/web_letter_crawler.py
+++ b/symbolic_ai/web/web_letter_crawler.py
@@ -1,5 +1,9 @@
-class WebLetterCrawler:
-    """Finds web content for letters."""
+from urllib.parse import urlparse
 
-    def crawl(self, url):
-        return ""
+
+class WebLetterCrawler:
+    """Extract words from a fake URL."""
+
+    def crawl(self, url: str) -> str:
+        path = urlparse(url).path
+        return path.strip("/")

--- a/symbolic_ai/web/youtube_letter_learner.py
+++ b/symbolic_ai/web/youtube_letter_learner.py
@@ -1,5 +1,5 @@
 class YouTubeLetterLearner:
-    """Scans videos for letter usage."""
+    """Pretend to learn letters from a YouTube URL."""
 
-    def learn(self, url):
-        return True
+    def learn(self, url: str) -> bool:
+        return url.startswith("http")


### PR DESCRIPTION
## Summary
- flesh out symbolic AI module implementations
- add basic symbolic memory manager using JSON storage
- implement simplistic algorithms for cognition, vision, audio, and tools
- provide working tests using unittest framework
- update README instructions and create gitignore

## Testing
- `python3 -m symbolic_ai.tests.test_all`

------
https://chatgpt.com/codex/tasks/task_e_68513b8ef300832d822233c5ed1c2149