### PR TITLE
Implement autonomous symbolic AI components

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
-from symbolic_ai.ai_autopilot import AutonomousAI
+from symbolic_ai.core.memory_manager import MemoryManager
+from symbolic_ai.core.learning_loop import LearningLoop
 
 
 def main() -> None:
@@ -7,8 +8,9 @@ def main() -> None:
     if source not in {"camera", "voice", "web"}:
         print("Unknown source, defaulting to camera")
         source = "camera"
-    ai = AutonomousAI(source)
-    ai.run()
+    memory = MemoryManager()
+    loop = LearningLoop(memory)
+    loop.run_autonomous(source)
 
 
 if __name__ == "__main__":

--- a/symbolic_ai/core/brain_controller.py
+++ b/symbolic_ai/core/brain_controller.py
@@ -3,9 +3,12 @@ class BrainController:
 
     def __init__(self, memory_manager: "MemoryManager"):
         self.memory = memory_manager
+        from symbolic_ai.logging.logger import log
+        self.log = log
 
     def run(self, input_letter: str) -> dict:
         """Generate a basic pattern for ``input_letter`` and store it."""
+        self.log(f"Creating pattern for {input_letter}")
         shape = ord(input_letter)
         pattern = {
             "symbol": input_letter,
@@ -13,4 +16,5 @@ class BrainController:
             "vector": [shape % 3, shape % 5, shape % 7],
         }
         self.memory.store(input_letter, pattern)
+        self.log(f"Stored pattern for {input_letter}")
         return pattern

--- a/symbolic_ai/logging/logger.py
+++ b/symbolic_ai/logging/logger.py
@@ -1,0 +1,2 @@
+def log(message: str) -> None:
+    print(f"[🧠 AI] {message}")

--- a/symbolic_ai/logic/symbol_recognizer.py
+++ b/symbolic_ai/logic/symbol_recognizer.py
@@ -1,12 +1,13 @@
 class SymbolRecognizer:
-    """Recognize known symbols or return best approximate match."""
+    """Recognize known symbols and return their stored pattern."""
 
     def __init__(self, memory_manager: "MemoryManager"):
         self.memory = memory_manager
 
-    def recognize(self, symbol: str) -> str:
+    def recognize(self, symbol: str) -> dict:
+        """Return pattern dict for ``symbol`` or closest match."""
         if symbol in self.memory.memory:
-            return symbol
+            return self.memory.memory[symbol][0]
         ascii_val = ord(symbol)
         best = None
         best_diff = float("inf")
@@ -15,4 +16,6 @@ class SymbolRecognizer:
             if diff < best_diff:
                 best = sym
                 best_diff = diff
-        return best if best is not None else ""
+        if best is not None:
+            return self.memory.memory[best][0]
+        return {}

--- a/symbolic_ai/logic/test_logic.py
+++ b/symbolic_ai/logic/test_logic.py
@@ -18,10 +18,10 @@ class TestLogic(unittest.TestCase):
 
     def test_recognizer(self):
         mem = MemoryManager()
-        mem.memory = {"a": [{"ascii": 97, "vector": [1]}]}
+        mem.memory = {"a": [{"symbol": "a", "ascii": 97, "vector": [1]}]}
         recog = SymbolRecognizer(mem)
-        self.assertEqual(recog.recognize("a"), "a")
-        self.assertEqual(recog.recognize("b"), "a")
+        self.assertEqual(recog.recognize("a")["symbol"], "a")
+        self.assertEqual(recog.recognize("b")["symbol"], "a")
 
     def test_logic_chain(self):
         chain = LogicChain()

--- a/symbolic_ai/tools/browser_reader.py
+++ b/symbolic_ai/tools/browser_reader.py
@@ -1,9 +1,38 @@
 import re
 
+try:  # optional requests import
+    import requests
+except Exception:  # pragma: no cover - requests may be missing
+    requests = None
+from html import unescape
+from urllib.request import urlopen
+
 
 class BrowserReader:
-    """Parses provided HTML text and returns plain text."""
+    """Fetch web pages and extract readable text."""
 
     def read(self, html: str) -> str:
         cleaned = re.sub(r"<[^>]+>", "", html or "")
-        return cleaned.strip()
+        return unescape(cleaned.strip())
+
+    def fetch_text(self, url: str) -> str:
+        """Download ``url`` using requests if available."""
+        html = ""
+        if requests:
+            try:
+                html = requests.get(url, timeout=5).text
+            except Exception:
+                html = ""
+        else:
+            try:
+                with urlopen(url, timeout=5) as resp:
+                    html = resp.read().decode("utf-8", errors="ignore")
+            except Exception:
+                html = ""
+        return self.extract(html)
+
+    def extract(self, html: str) -> str:
+        """Return text from bold/headline/link/paragraph tags."""
+        matches = re.findall(r"<(b|strong|h[1-6]|a|p)[^>]*>(.*?)</[^>]+>", html, re.I | re.S)
+        text = " ".join(unescape(m[1]).strip() for m in matches)
+        return self.read(text)

--- a/symbolic_ai/tools/camera_handler.py
+++ b/symbolic_ai/tools/camera_handler.py
@@ -1,6 +1,21 @@
+try:  # optional OpenCV import
+    import cv2
+except Exception:  # pragma: no cover - OpenCV may be missing
+    cv2 = None
+
+
 class CameraHandler:
-    """Handles webcam capture (returns 1x1 pixel matrix)."""
+    """Handles webcam capture using OpenCV when available."""
+
+    def __init__(self) -> None:
+        self.cap = cv2.VideoCapture(0) if cv2 else None
 
     def capture(self) -> list[list[int]]:
-        """Return a single white pixel represented as nested list."""
+        """Capture a small grayscale matrix from the webcam."""
+        if self.cap:
+            ret, frame = self.cap.read()
+            if ret:
+                gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+                small = cv2.resize(gray, (5, 5))
+                return small.tolist()
         return [[255]]

--- a/symbolic_ai/tools/speech_transcriber.py
+++ b/symbolic_ai/tools/speech_transcriber.py
@@ -1,5 +1,23 @@
+try:  # optional speech_recognition import
+    import speech_recognition as sr
+except Exception:  # pragma: no cover - library may be missing
+    sr = None
+
+
 class SpeechTranscriber:
-    """Converts raw bytes to a UTF-8 string (mock transcription)."""
+    """Transcribe audio or live microphone input into text."""
+
+    def __init__(self) -> None:
+        if sr:
+            try:
+                self.rec = sr.Recognizer()
+                self.mic = sr.Microphone()
+            except Exception:  # pragma: no cover - microphone not available
+                self.rec = None
+                self.mic = None
+        else:
+            self.rec = None
+            self.mic = None
 
     def transcribe(self, audio: bytes | str) -> str:
         if isinstance(audio, bytes):
@@ -8,3 +26,16 @@ class SpeechTranscriber:
             except Exception:
                 return ""
         return str(audio or "")
+
+    def listen_live(self) -> list[str]:
+        """Capture speech from the microphone and return tokens."""
+        if self.rec and self.mic:
+            with self.mic as source:
+                audio = self.rec.listen(source)
+            try:
+                text = self.rec.recognize_google(audio)
+            except Exception:  # pragma: no cover - recognition may fail
+                text = ""
+        else:
+            text = input("\U0001F399 Speak words: ")
+        return [t for t in text.split() if t]


### PR DESCRIPTION
## Summary
- add logging helper with `[🧠 AI]` prefix
- capture webcam frames using OpenCV when possible
- allow live microphone transcription via SpeechRecognition
- fetch web pages with requests fallback and parse key tags
- log pattern creation in `BrainController`
- expand `LearningLoop` to autonomously fetch symbols and reason
- modify `SymbolRecognizer` to return full pattern info
- update tests for new behaviour
- switch `main.py` to run `LearningLoop`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685155086720832db0e967b022e7fae1